### PR TITLE
Remove the mutex and add an auto_flush option for OpenAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2024-02-27
+
+### Added
+
+- Added `auto_flush` option to the OpenAI integration to automatically flush after each API call
+- Added comprehensive tests for the `auto_flush` functionality
+
+### Changed
+
+- Removed mutex locks in favor of using Ruby's thread-safe Queue class directly
+- Simplified the queue operations for better thread safety
+- Improved background timer implementation
+
+### Fixed
+
+- Fixed potential deadlocks in multi-threaded environments like Sidekiq
+- Fixed race conditions in the flush mechanism
+
+## [0.1.0] - 2024-02-24
+
+### Added
+
+- Initial release of the Langfuse Ruby client
+- Core functionality for creating traces, generations, spans, and events
+- OpenAI integration for automatic tracing of API calls
+- Thread-local client support for multi-threaded environments
+- Batch processing with automatic flushing
+- Comprehensive test suite

--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ response = traced_client.chat(
 traced_client.flush_async
 ```
 
+#### Auto-Flush Option
+
+You can enable automatic flushing after each OpenAI call by setting the `auto_flush` option:
+
+```ruby
+# Create a traced client with auto-flush enabled
+traced_client = Langfuse::OpenAI.observe(openai_client, {
+  public_key: ENV['LANGFUSE_PUBLIC_KEY'],
+  secret_key: ENV['LANGFUSE_SECRET_KEY'],
+  auto_flush: true  # Will flush after each API call
+})
+
+# No need to call flush_async manually - it happens automatically after each call
+response = traced_client.chat(parameters: { /* ... */ })
+```
+
+This is particularly useful in serverless environments or when you want to ensure data is sent to Langfuse immediately after each API call.
+
 ### Create traces manually
 
 ```ruby
@@ -94,6 +112,87 @@ generation = trace.generation(
 
 # Make sure to flush at the end of your process
 langfuse.flush
+```
+
+### Thread Safety and Sidekiq Integration
+
+When using Langfuse in multi-threaded environments like Sidekiq, the client provides thread-safe options to prevent deadlocks or recursive locking errors:
+
+#### Using Thread-Local Clients
+
+For Sidekiq workers, it's recommended to use thread-local clients to avoid sharing state between workers:
+
+```ruby
+class MyLLMWorker
+  include Sidekiq::Worker
+
+  def perform(user_id, query)
+    # Get a thread-local client for this worker
+    langfuse = Langfuse.thread_local_client(
+      public_key: ENV['LANGFUSE_PUBLIC_KEY'],
+      secret_key: ENV['LANGFUSE_SECRET_KEY']
+    )
+
+    # Create a trace
+    trace = langfuse.trace(
+      name: "Sidekiq LLM Query",
+      user_id: user_id
+    )
+
+    # Your LLM logic here...
+
+    # Explicitly flush before the worker completes
+    langfuse.flush
+
+    # Clear the thread-local client to free resources
+    Langfuse.clear_thread_local_client
+  end
+end
+```
+
+#### Thread-Safe Configuration Options
+
+The client supports options to improve thread safety:
+
+```ruby
+langfuse = Langfuse.new(
+  public_key: 'pk-...',
+  secret_key: 'sk-...',
+  # Thread safety options
+  disable_background_flush: true,   # Disable background flush timer (recommended for Sidekiq)
+)
+```
+
+#### OpenAI Integration in Sidekiq
+
+When using the OpenAI integration in Sidekiq, create a new traced client for each job:
+
+```ruby
+class OpenAIWorker
+  include Sidekiq::Worker
+
+  def perform(user_id, prompt)
+    # Create a fresh OpenAI client for this job
+    openai_client = OpenAI::Client.new(access_token: ENV['OPENAI_API_KEY'])
+
+    # Create a traced client with thread-safe options
+    traced_client = Langfuse::OpenAI.observe(openai_client, {
+      public_key: ENV['LANGFUSE_PUBLIC_KEY'],
+      secret_key: ENV['LANGFUSE_SECRET_KEY'],
+      user_id: user_id,
+      disable_background_flush: true,  # Important for Sidekiq
+      auto_flush: true  # Automatically flush after each API call
+    })
+
+    # Make the API call
+    response = traced_client.chat(parameters: {
+      model: "gpt-3.5-turbo",
+      messages: [{ role: "user", content: prompt }]
+    })
+
+    # With auto_flush enabled, no need to call flush_async manually
+  end
+end
 ```
 
 ## Development

--- a/lib/langfuse.rb
+++ b/lib/langfuse.rb
@@ -3,18 +3,18 @@ require 'faraday'
 require 'json'
 require 'securerandom'
 require 'logger'
-require 'singleton'
+require 'thread'
 
 # Load version first
 require_relative 'langfuse/version'
 
 module Langfuse
   class Error < StandardError; end
-  
+
   # Load all components within the module scope
   require_relative 'langfuse/core'
   require_relative 'langfuse/openai'
-  
+
   # Create a new Langfuse client instance
   # @param public_key [String] Langfuse public key
   # @param secret_key [String] Langfuse secret key
@@ -26,6 +26,7 @@ module Langfuse
   # @option options [Integer] :retry_delay Delay between retries in seconds (default: 1)
   # @option options [Boolean] :enabled Whether this client is enabled (default: true)
   # @option options [Float] :sample_rate Sampling rate between 0 and 1 (default: 1.0)
+  # @option options [Boolean] :disable_background_flush Disable background flush timer thread (default: false)
   # @return [Langfuse::Core] A new Langfuse client
   def self.new(public_key:, secret_key:, host: 'https://cloud.langfuse.com', **options)
     Langfuse::Core.new(
@@ -34,5 +35,36 @@ module Langfuse
       host: host,
       **options
     )
+  end
+
+  # Get a thread-local Langfuse client
+  # This is useful for multi-threaded environments like Sidekiq
+  # @param public_key [String] Langfuse public key
+  # @param secret_key [String] Langfuse secret key
+  # @param host [String] Langfuse host URL (default: 'https://cloud.langfuse.com')
+  # @param options [Hash] Additional options (see #new for details)
+  # @return [Langfuse::Core] A thread-local Langfuse client
+  def self.thread_local_client(public_key:, secret_key:, host: 'https://cloud.langfuse.com', **options)
+    thread_key = :langfuse_thread_local_client
+
+    # Return existing client if it exists for this thread
+    return Thread.current[thread_key] if Thread.current[thread_key]
+
+    # Create a new client with background flush disabled by default for thread-local clients
+    options[:disable_background_flush] = true unless options.key?(:disable_background_flush)
+
+    # Create and store the client
+    Thread.current[thread_key] = Langfuse::Core.new(
+      public_key: public_key,
+      secret_key: secret_key,
+      host: host,
+      **options
+    )
+  end
+
+  # Clear the thread-local client
+  # Call this when you're done with the client to free resources
+  def self.clear_thread_local_client
+    Thread.current[:langfuse_thread_local_client] = nil
   end
 end

--- a/lib/langfuse/version.rb
+++ b/lib/langfuse/version.rb
@@ -1,3 +1,3 @@
 module Langfuse
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
### Added

- Added `auto_flush` option to the OpenAI integration to automatically flush after each API call
- Added comprehensive tests for the `auto_flush` functionality

### Changed

- Removed mutex locks in favor of using Ruby's thread-safe Queue class directly
- Simplified the queue operations for better thread safety
- Improved background timer implementation

### Fixed

- Fixed potential deadlocks in multi-threaded environments like Sidekiq
- Fixed race conditions in the flush mechanism